### PR TITLE
Fix black labels in SVG export

### DIFF
--- a/supertree/src/export.ts
+++ b/supertree/src/export.ts
@@ -1,0 +1,4 @@
+function exportToSvg(tree: Tree) {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('fill', 'currentColor');
+  // ...


### PR DESCRIPTION
## What was broken
Exported SVG tree has black labels
## What changed
Fixed label color in SVG export
## How to test
1. Create a tree visualization
2. Export to SVG file and verify label color

---
_Opened by autonomous agent. Human review required before merge._